### PR TITLE
Remove empty `Deps` field

### DIFF
--- a/pop3.nimble
+++ b/pop3.nimble
@@ -4,6 +4,3 @@ version: "0.1"
 author: "Federico Ceratto"
 description: "POP3 client library"
 license: "LGPLv3"
-
-[Deps]
-requires: ""


### PR DESCRIPTION
This is *really* messing with newer versions of Nimble